### PR TITLE
Add Header component test

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@
 
 **Zombi Phone** es una innovadora operadora de telefonía que ofrece servicios únicos y personalizados para todos los usuarios. Nos especializamos en brindar soluciones de comunicación de alta calidad, con tarifas competitivas y un servicio al cliente excepcional.
 
+
+## Tests
+
+Este proyecto utiliza Vitest y React Testing Library para las pruebas.
+Ejecuta `npm test` para correr todas las pruebas unitarias.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "autoprefixer": "^10.4.19",
@@ -29,7 +30,11 @@
     "eslint-plugin-react-refresh": "^0.4.9",
     "tailwindcss": "^3.4.7",
     "typescript": "^5.2.2",
-    "vite": "^5.3.4"
+    "vite": "^5.3.4",
+    "vitest": "^1.5.1",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.1.4",
+    "jsdom": "^24.0.0"
   },
   "settings": {
     "react": {

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Header from '../Header';
+import React from 'react';
+
+describe('Header', () => {
+  it('renders phone number', () => {
+    render(
+      <Header
+        content={{
+          logo: <div>Logo</div>,
+          menu: <div>Menu</div>,
+          contact: <div>666 777 888</div>,
+        }}
+      />,
+    );
+    expect(screen.getByText('666 777 888')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -1,3 +1,4 @@
+// Unit test for Header component
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Header from '../Header';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,4 +5,8 @@ import tailwindcss from 'tailwindcss';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
 })


### PR DESCRIPTION
## Summary
- add test script and test dependencies in package.json
- configure Vitest for jsdom
- create Header component test checking phone number

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684027477994832c860937d4ec572d3f